### PR TITLE
Regex getIconvVersion accounts for ending bracket

### DIFF
--- a/tasks/encoding.js
+++ b/tasks/encoding.js
@@ -44,7 +44,7 @@ function getIconvVersion(executable, callback) {
         } else if (code !== 0) {
             callback(new Error('iconv exited with code ' + code));
         } else {
-            var matches = stdout.match(/^iconv (?:.+?) (\d+\.\d+(?:\.\d+)?)$/m);
+            var matches = stdout.match(/^iconv (?:.+?) (\d+\.\d+(?:\.\d+)?).*$/m);
             callback(null, matches ? matches[1] : '<unknown>');
         }
     });


### PR DESCRIPTION
Iconv version output looks something like:

```
  iconv (GNU libiconv 1.14)
  Copyright (C) 2000-2011 Free Software Foundation, Inc.
  License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
  This is free software: you are free to change and redistribute it.
  There is NO WARRANTY, to the extent permitted by law.
  Written by Bruno Haible.
```

The previous regex matched till `iconv (GNU libiconv 1.14` but did not account for the trailing bracket, resulting in no matches.

Since we have /m, it is safe to just add .*$ after we get our relevant part (the version number)
